### PR TITLE
added note to avoid jupyter port listening conflict

### DIFF
--- a/latex/sections/1_2_preparation.tex
+++ b/latex/sections/1_2_preparation.tex
@@ -16,6 +16,8 @@ We will use \texttt{jupyter} in section \ref{sec:querybuilder} and optionally in
 
 Now launch an identical \cmd{ssh} connection (again, as explained above) in another terminal, and type \texttt{workon aiida} here too. This terminal is the one you will actually use in this tutorial.
 
+Note: Since the port listening is set to a specific port (8888) in the section \ref{sec:sshintro}, you have to make sure on the server the Jupiter notebook is running on the port 8888. Otherwise, use an alternative port for listening. 
+
 % \textbf{We suggest to open two terminals with such an \cmd{ssh} connection}:
 
 A final note: for details on AiiDA that may not be fully explained here, you can refer to the full AiiDA documentation, available online at \url{http://aiida-core.readthedocs.io/en/latest/}.


### PR DESCRIPTION
If Jupyter notebook is running on a different port on the server, the user won't be able to open the notebook on the local machine. Ths note helps to change either the listening port, identical to the forwarding port on the server or change the forwarding port on the server similar to the listening port. 